### PR TITLE
add fallback to open node if cln not running on start

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -118,11 +118,16 @@ func main() {
 		app.Err.Fatal(err)
 	}
 
+
 	/* If we're using the CLN backend, init
 	 * the checkout runner */
-	err = setupCLNCheckout(&app)
-	if err != nil {
-		app.Err.Fatal(err)
+	 if app.Env.UseCLN {
+		err = setupCLNCheckout(&app)
+		if err != nil {
+			app.Err.Printf("Warning: CLN checkout setup failed: %v", err)
+			app.Env.UseCLN = false
+			app.Err.Printf("CLN checkout disabled, Falling back to OpenNode")
+		}
 	}
 
 	srv := &http.Server{


### PR DESCRIPTION
see title.  

This small change is a Simple fallback which

1.  allows the web app to run if the CLN node  is not running. previously, if there was no CLN running the app would not start.
2. if the CLN node is not running, the app will fallback to use OpenNode

Note: While this doesn't handle the case for CLN node failure while server is running, it allows options on server start.