### PR TITLE
remove redundant class declaration

### DIFF
--- a/templates/conf/berlin25.tmpl
+++ b/templates/conf/berlin25.tmpl
@@ -233,7 +233,6 @@
       <div class="mt-10 flex items-center justify-center gap-x-6">
         <a href="https://lightning.devpost.com/?preview_token=LOmLADd9ksRg3gj%2B33V4qQFnQj62aUILDG9dDm8FaLs%3D" target="_blank" 
 	class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 berlin25">Find out more on Devpost</a>
-	class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">Find out more on Devpost</a>
       </div>
       <svg viewBox="0 0 1024 1024" class="absolute left-1/2 top-1/2 -z-10 size-[64rem] -translate-x-1/2 [mask-image:radial-gradient(closest-side,white,transparent)]" aria-hidden="true">
         <circle cx="512" cy="512" r="512" fill="#fff" fill-opacity="0.7" />


### PR DESCRIPTION
this was annoying me. You have two class declarations in the same tag. 
Wasn't able to build locally to verify but I think this should fix it.

<img width="1367" height="536" alt="Screenshot From 2025-08-27 09-43-04" src="https://github.com/user-attachments/assets/e825ac4b-7b6c-4157-aeb4-18a8185714ce" />
